### PR TITLE
Update to use new school opening hours method in meter collection

### DIFF
--- a/app/models/meter_collection.rb
+++ b/app/models/meter_collection.rb
@@ -133,17 +133,10 @@ class MeterCollection
     @meter_identifier_lookup[meter.id] = meter
   end
 
-  # JAMES: TODO(JJ,3Jun2018): I gather you may have done something on this when working on holidays?
-  def open_time
-    @cached_open_time
-  end
-
-  def close_time
-    @cached_close_time
-  end
-
-  def school_day_in_hours(time_of_day)
-    time_of_day >= open_time && time_of_day < close_time
+  # This is overridden in the energysparks code at the moment, to use the actual open/close times
+  # It replaces school_day_in_hours(time_of_day)
+  def is_school_usually_open?(_date, time_of_day)
+    time_of_day >= @cached_open_time && time_of_day < @cached_close_time
   end
 
   # held at building level as a school building e.g. a community swimming pool may have a different holiday schedule

--- a/lib/dashboard/charting_and_reports/series_data_manager.rb
+++ b/lib/dashboard/charting_and_reports/series_data_manager.rb
@@ -392,8 +392,8 @@ private
         else
           (0..47).each do |halfhour_index|
             # Time is an order of magnitude slower than DateTime on Windows
-            dt = DateTimeHelper.time_of_day(halfhour_index)
-            daytype_type = @meter_collection.school_day_in_hours(dt) ? SeriesNames::SCHOOLDAYOPEN : SeriesNames::SCHOOLDAYCLOSED
+            time_of_day = DateTimeHelper.time_of_day(halfhour_index)
+            daytype_type = @meter_collection.is_school_usually_open?(date, time_of_day) ? SeriesNames::SCHOOLDAYOPEN : SeriesNames::SCHOOLDAYCLOSED
             daytype_data[daytype_type] += meter.amr_data.kwh(date, halfhour_index) * factor
           end
         end
@@ -420,8 +420,8 @@ private
     elsif DateTimeHelper.weekend?(date)
       daytype_data[SeriesNames::WEEKEND] = val
     else
-      dt = DateTimeHelper.time_of_day(halfhour_index)
-      daytype_type = @meter_collection.school_day_in_hours(dt) ? SeriesNames::SCHOOLDAYOPEN : SeriesNames::SCHOOLDAYCLOSED
+      time_of_day = DateTimeHelper.time_of_day(halfhour_index)
+      daytype_type = @meter_collection.is_school_usually_open?(date, time_of_day) ? SeriesNames::SCHOOLDAYOPEN : SeriesNames::SCHOOLDAYCLOSED
       daytype_data[daytype_type] = val
     end
 

--- a/lib/dashboard/simulator/building_heat_hw_simulator.rb
+++ b/lib/dashboard/simulator/building_heat_hw_simulator.rb
@@ -32,7 +32,7 @@ class BuildingHeatHWSimulator
   end
 
   def create_empty_data(type)
-    data = {} 
+    data = {}
     (simulation_start_date..simulation_end_date).each do |date|
       data[date] = Array.new(48 * simulation_frequency, 0.0)
     end
@@ -41,7 +41,8 @@ class BuildingHeatHWSimulator
   end
 
   def occupied_date_time?(date, day_index)
-    occupied?(date) && school.school_day_in_hours(time_of_day(day_index))
+    # Note - is_school_usually_open? is currently defined at meter collection level
+    occupied?(date) && school.is_school_usually_open?(date, time_of_day(day_index))
   end
 
   def occupied?(date)
@@ -221,7 +222,7 @@ class BuildingHeatHWSimulator
   end
 
   def admittance_kw(delta_t)
-    ad = total_internal_external_wall_area * construction_heat_admittance_kw_per_m2_per_k(:dense_masonary_cavity_wet_plaster) 
+    ad = total_internal_external_wall_area * construction_heat_admittance_kw_per_m2_per_k(:dense_masonary_cavity_wet_plaster)
     ad += school.floor_area * construction_heat_admittance_kw_per_m2_per_k(:dense_masonary_cavity_wet_plaster) * 0.5
     ad * delta_t
   end
@@ -243,14 +244,14 @@ class BuildingHeatHWSimulator
     losses_kw_per_k =   air_heat_loss_kw(uncontrolled_air_permeability_m3_per_hr(nil, nil), 1.0) +
                         air_heat_loss_kw(controlled_air_permeability_m3_per_hr(nil, nil), 1.0) +
                         fabric_loss_kw_per_k
-    set_point_temperature - (gains_kw / losses_kw_per_k)      
+    set_point_temperature - (gains_kw / losses_kw_per_k)
   end
 
   def balance_point_unoccupied
     gains_kw = unoccupied_electrical_gain_kw
     losses_kw_per_k =   air_heat_loss_kw(uncontrolled_air_permeability_m3_per_hr(nil, nil), 1.0) +
                         fabric_loss_kw_per_k
-    set_point_temperature - (gains_kw / losses_kw_per_k) 
+    set_point_temperature - (gains_kw / losses_kw_per_k)
   end
 
   LOG_DEFINITION = {
@@ -340,7 +341,7 @@ class BuildingHeatHWSimulator
         #     e.g. 3 kW - 1.6dK - 0.6dK = 0; dK = 3/(1.6 + 0.6) = 1.4C i.e. at 20C - 1.4C = Tbp = 18.6C external
         #          FYI: the occupied balance point is e.g.
         #          36 kW - 1.6dK - 0.6dK - 1.2dK; dK = 10.6K => Tbp = 9.6C external
-        #   -         
+        #   -
         # if negative i.e. providing heat:
         #   - it can't be more than the net internal loss (-tve gain)
         admittance = admittance_kw(internal_temp - wall_temp)
@@ -397,7 +398,7 @@ rate_of_wall_heating_per_hour = 1.0
   def save_raw_data_to_csv_for_debug(filename, meta_data_log)
     filepath = File.join(File.dirname(__FILE__), '../../../log/' + filename)
 
-    File.open(filepath, 'w') do |file| 
+    File.open(filepath, 'w') do |file|
       meta_data_log.each do |key, value|
         file.puts("#{key},#{value}")
       end
@@ -413,7 +414,7 @@ rate_of_wall_heating_per_hour = 1.0
         end
       end
     end
-  end  
+  end
 
   def self.default_configuration_deprecated(school)
     building = {


### PR DESCRIPTION
This is to replace the cached open/closed times with the actual open closed times for a school. At some point it should be refactored out of meter collection and in to school, but this is a 'getting it working' patch. 

Apologies for the white-space changes, my editors all automatically trim white space when saving a file.