### PR TITLE
Patch for analysis tables and y axis conversion

### DIFF
--- a/lib/dashboard/charting_and_reports/dashboard_analysis_advice.rb
+++ b/lib/dashboard/charting_and_reports/dashboard_analysis_advice.rb
@@ -221,6 +221,7 @@ protected
     data.each_value do |value|
       total += value[0]
     end
+
     template = %{
       <table class="table table-striped table-sm">
         <thead>
@@ -239,7 +240,7 @@ protected
               <td><%= row %></td>
               <% val = value[0] %>
               <% pct = val / total %>
-              <td class="text-right"><%= FormatEnergyUnit.scale_num(val) %></td>
+              <td class="text-right"><%= YAxisScaling.convert(units, :kwh, fuel_type, val) %></td>
               <% if row.match(/export/i) %>
                 <td class="text-right"><%= YAxisScaling.convert(units, :£, :solar_export, val) %></td>
               <% else %>
@@ -254,7 +255,7 @@ protected
           <% if totals_row %>
             <tr class="table-success">
               <td><b>Total</b></td>
-              <td class="text-right table-success"><b><%= FormatEnergyUnit.scale_num(total) %></b></td>
+              <td class="text-right table-success"><b><%= YAxisScaling.convert(units, :kwh, fuel_type, total) %></b></td>
               <td class="text-right table-success"><b><%= YAxisScaling.convert(units, :£, fuel_type, total) %></b></td>
               <td class="text-right table-success"><b><%= YAxisScaling.convert(units, :co2, fuel_type, total) %></b></td>
               <td class="text-right table-success"><b><%= YAxisScaling.convert(units, :library_books, fuel_type, total) %></b></td>

--- a/lib/dashboard/version.rb
+++ b/lib/dashboard/version.rb
@@ -1,3 +1,3 @@
 module Dashboard
-  VERSION = "0.31.15".freeze
+  VERSION = "0.32.2".freeze
 end


### PR DESCRIPTION
My understanding is that the values in the table all need converting from whatever values are used to create the pie chart. Currently the kWh column doesn't get converted and instead displays whatever values are used to create the pie chart. 

This patch ensures the kWh column is converted back to kWh for display.