### PR TITLE
Patch to dashboard analysis exemplar percentage and fix for bath gas

### DIFF
--- a/app/models/meter_attributes.rb
+++ b/app/models/meter_attributes.rb
@@ -16,12 +16,11 @@ class MeterAttributes
       weekend_correction = { auto_insert_missing_readings: { type: :weekends }}
 
       if attributes.key?(:meter_corrections)
-        meter_corrections_array = attributes[:meter_corrections]
-        unless meter_corrections_array.detect { |h| h.is_a?(Hash) && h.key?(:auto_insert_missing_readings) }
-          meter_corrections_array << weekend_correction
+        unless attributes[:meter_corrections].detect { |h| h.is_a?(Hash) && h.key?(:auto_insert_missing_readings) }
+          attributes[:meter_corrections] << weekend_correction
         end
       else
-        meter_corrections_array = [weekend_correction]
+        attributes[:meter_corrections] = [weekend_correction]
       end
     end
     attributes
@@ -389,7 +388,7 @@ class MeterAttributes
           readings_start_date: Date.new(2010, 6, 25),
           reason: 'Probably not needed, LGAP lost during testing of bulk upload PH 4Mar2019, suggest remove on further review'
         },
-      ]
+      ],
       heating_model: {
         max_summer_daily_heating_kwh:     25,
         reason: 'Staton Drew has strange bifurcation, suggesting half the storage heaters are switched off much earlier in the year'

--- a/lib/dashboard/charting_and_reports/dashboard_analysis_advice.rb
+++ b/lib/dashboard/charting_and_reports/dashboard_analysis_advice.rb
@@ -362,7 +362,7 @@ class BenchmarkComparisonAdvice < DashboardChartAdviceBase
 
   def generate_advice
     logger.info @school.name
-    
+
     electric_usage = get_energy_usage('electricity', :electricity, index_of_most_recent_date)
     gas_usage = get_energy_usage('gas', :gas, index_of_most_recent_date)
     gas_only = electric_usage.nil?
@@ -559,7 +559,7 @@ class FuelDaytypeAdvice < DashboardChartAdviceBase
           <%= percent(percent_value) %> of your <%= @fuel_type_str %> usage is out of hours:
           which is <%= adjective(percent_value, BENCHMARK_PERCENT) %>
           of <%= percent(BENCHMARK_PERCENT) %>.
-          <% if percent_value > EXEMPLAR_PERCENT %>
+          <% if percent_value > @exemplar_percentage %>
             The best schools only consume <%= percent(@exemplar_percentage) %> out of hours.
             Reducing your school's out of hours usage to <%= percent(@exemplar_percentage) %>
             would save <%= pounds_to_pounds_and_kwh(saving_£, @fuel_type) %> per year.

--- a/lib/dashboard/version.rb
+++ b/lib/dashboard/version.rb
@@ -1,3 +1,3 @@
 module Dashboard
-  VERSION = "0.41.7".freeze
+  VERSION = "0.41.8".freeze
 end


### PR DESCRIPTION
- Bath Gas wasn't working (JJ fault)
- missing comma in meter attributes structure caused problems
- dashboard analysis advice had an EXEMPLAR_PERCENTAGE which should have been replaced