### PR TITLE
Refactor meter collection for yaml dumps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'chroma'
 
 # Useful for debugging
 gem 'pry-byebug'
-gem 'hashdiff'
+gem 'hashdiff', '~> 1.0.0'
 
 # For profiling code
 gem 'ruby-prof'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     extendmatrix (0.4)
     ffi (1.9.25)
     ffi (1.9.25-x64-mingw32)
-    hashdiff (0.3.7)
+    hashdiff (1.0.0)
     hashie (3.5.7)
     html-table (1.5.1)
       strongtyping
@@ -163,7 +163,7 @@ DEPENDENCIES
   activesupport (~> 6.0.0.rc1)
   benchmark-memory
   chroma
-  hashdiff
+  hashdiff (~> 1.0.0)
   html-table
   interpolate
   mechanize

--- a/energy-sparks_analytics.gemspec
+++ b/energy-sparks_analytics.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'soda-ruby', '~> 0.2.25'
   s.add_dependency 'structured_warnings', '~> 0.3.0'
   s.add_dependency 'chroma', '~> 0.2.0'
-  s.add_dependency 'hashdiff', '~> 0.4.0'
+  s.add_dependency 'hashdiff', '~> 1.0.0'
 
   # For profiling code
   s.add_dependency 'ruby-prof', '~> 0.17.0'

--- a/lib/dashboard/version.rb
+++ b/lib/dashboard/version.rb
@@ -1,7 +1,3 @@
 module Dashboard
-<<<<<<< HEAD
-  VERSION = "0.50.10"
-=======
-  VERSION = "0.50.11"
->>>>>>> master
+  VERSION = "0.50.12"
 end

--- a/lib/dashboard/version.rb
+++ b/lib/dashboard/version.rb
@@ -1,3 +1,3 @@
 module Dashboard
-  VERSION = "0.50.5"
+  VERSION = "0.50.6"
 end

--- a/lib/dashboard/version.rb
+++ b/lib/dashboard/version.rb
@@ -1,3 +1,3 @@
 module Dashboard
-  VERSION = "0.50.9"
+  VERSION = "0.50.10"
 end

--- a/lib/dashboard/version.rb
+++ b/lib/dashboard/version.rb
@@ -1,3 +1,3 @@
 module Dashboard
-  VERSION = "0.50.4"
+  VERSION = "0.50.5"
 end

--- a/script/alert_benchmarking.rb
+++ b/script/alert_benchmarking.rb
@@ -185,7 +185,7 @@ end
 history.save(calculated_results)
 
 print_banner "Differences:"
-h_diff = HashDiff.diff(previous_results, calculated_results, use_lcs: false, :numeric_tolerance => 0.01)
+h_diff = Hashdiff.diff(previous_results, calculated_results, use_lcs: false, :numeric_tolerance => 0.01)
 puts h_diff
 
 print_banner "Calc times:"

--- a/script/report_config_support.rb
+++ b/script/report_config_support.rb
@@ -242,7 +242,7 @@ class ReportConfigSupport
     unless diff # HashDiff is horribly slow, so only run if necessary
       puts "+" * 120
       puts "Chart #{chart_name} differs"
-      h_diff = HashDiff.diff(old_data, new_data, use_lcs: false, :numeric_tolerance => 0.000001) # use_lcs is O(N) otherwise and takes hours!!!!!
+      h_diff = Hashdiff.diff(old_data, new_data, use_lcs: false, :numeric_tolerance => 0.000001) # use_lcs is O(N) otherwise and takes hours!!!!!
       if @@energysparksanalyticsautotest[:skip_advice] && h_diff.to_s.include?('html')
         puts 'Advice differs'
       else

--- a/script/test_alerts.rb
+++ b/script/test_alerts.rb
@@ -202,7 +202,7 @@ end
 =begin
 history.save(calculated_results)
 =end
-# h_diff = HashDiff.diff(previous_results, calculated_results, use_lcs: false, :numeric_tolerance => 0.01)
+# h_diff = Hashdiff.diff(previous_results, calculated_results, use_lcs: false, :numeric_tolerance => 0.01)
 # puts h_diff
 
 alert_calculation_time.each do |type, data|

--- a/test_support/compare_charts.rb
+++ b/test_support/compare_charts.rb
@@ -66,7 +66,7 @@ class CompareChartResults
     else
       @differing_results[chart_name] = true # set for summary purposes
       if !control_contains?(:quick_comparison) # HashDiff is horribly slow, so only run if necessary
-        h_diff = HashDiff.diff(old_data, new_data, use_lcs: false, :numeric_tolerance => 0.000001) # use_lcs is O(N) otherwise and takes hours!!!!!
+        h_diff = Hashdiff.diff(old_data, new_data, use_lcs: false, :numeric_tolerance => 0.000001) # use_lcs is O(N) otherwise and takes hours!!!!!
         @differing_results[chart_name] = h_diff
         puts h_diff
       end

--- a/test_support/local_school_and_meter_metadata_db.rb
+++ b/test_support/local_school_and_meter_metadata_db.rb
@@ -128,7 +128,21 @@ class AnalysticsSchoolAndMeterMetaData
 
   def create_meter_collection(school_name, school_metadata, meter_metadata)
     school = create_school(school_name)
-    meter_collection = MeterCollection.new(school, ScheduleDataManager)
+
+    # This was previously in meter collection
+    holiday_schedule_name = school.area_name.nil? ? ScheduleDataManager::BATH_AREA_NAME : school.area_name
+    temperature_schedule_name = school.area_name.nil? ? ScheduleDataManager::BATH_AREA_NAME : school.area_name
+    solar_irradiance_schedule_name = school.area_name.nil? ? ScheduleDataManager::BATH_AREA_NAME : school.area_name
+    solar_pv_schedule_name = school.area_name.nil? ? ScheduleDataManager::BATH_AREA_NAME : school.area_name
+
+    # Now we pass in the data independently
+    meter_collection = MeterCollection.new(school,
+      temperatures: ScheduleDataManager.temperatures(temperature_schedule_name)
+      solar_pv: ScheduleDataManager.solar_pv(solar_pv_schedule_name)
+      solar_irradiation: ScheduleDataManager.solar_irradiation(solar_irradiance_schedule_name)
+      uk_grid_carbon_intensity: ScheduleDataManager.uk_grid_carbon_intensity
+      holidays: ScheduleDataManager.holidays(holiday_schedule_name)
+    )
 
     gas_meters = create_meters(meter_collection, school_metadata[:meters], :gas)
     gas_meters.each do |gas_meter|

--- a/test_support/run_alerts.rb
+++ b/test_support/run_alerts.rb
@@ -140,7 +140,7 @@ class RunAlerts
       differs = data != previous_data
       puts "differs: #{filename}" if !control[:save_and_compare][:summary].nil? && differs
       if differs && !control[:save_and_compare][:h_diff].nil?
-        h_diff = HashDiff.diff(previous_data, data, control[:save_and_compare][:h_diff]) do |_path, obj1, obj2|
+        h_diff = Hashdiff.diff(previous_data, data, control[:save_and_compare][:h_diff]) do |_path, obj1, obj2|
           obj1.is_a?(Float) && obj2.is_a?(Float) && obj1.nan? && obj2.nan? ? true : nil # make NaN == NaN, produces a [] result
         end
         ap h_diff
@@ -369,7 +369,7 @@ class RunAlerts
     history.save(calculated_results)
 
     print_banner "Differences:"
-    h_diff = HashDiff.diff(previous_results, calculated_results, use_lcs: false, :numeric_tolerance => 0.01)
+    h_diff = Hashdiff.diff(previous_results, calculated_results, use_lcs: false, :numeric_tolerance => 0.01)
     puts h_diff
 
     print_banner "Calc times:"


### PR DESCRIPTION
This relatively simple change means we can export meter collections as YAML files from the web application without any of the front end classes being included. Currently the ScheduleDataManager replacement would also be exported which is not good for the analytics code.