### PR TITLE
Patch for bad data summary

### DIFF
--- a/app/services/meter_collection_factory.rb
+++ b/app/services/meter_collection_factory.rb
@@ -66,7 +66,7 @@ class MeterCollectionFactory
   def build_meter(meter_collection, meter_data)
     amr_data = AMRData.new(meter_data[:type])
     meter_data[:readings].each do |reading|
-      amr_data.add(reading[:reading_date], OneDayAMRReading.new(meter_data[:external_meter_id], reading[:reading_date], reading[:type], reading[:substitute_date], reading[:upload_datetime], reading[:kwh_data_x48]))
+      amr_data.add(reading[:reading_date], OneDayAMRReading.new(meter_data[:identifier], reading[:reading_date], reading[:type], reading[:substitute_date], reading[:upload_datetime], reading[:kwh_data_x48]))
     end
     Dashboard::Meter.new(
       meter_collection:   meter_collection,

--- a/lib/dashboard/aggregation/amr_data.rb
+++ b/lib/dashboard/aggregation/amr_data.rb
@@ -321,7 +321,7 @@ class AMRData < HalfHourlyData
   def summarise_bad_data
     date, one_days_data = self.first
     logger.info '=' * 80
-    logger.info "Bad data for meter #{one_days_data.mpan_mprn}"
+    logger.info "Bad data for meter #{one_days_data.meter_id}"
     logger.info "Valid data between #{start_date} and #{end_date}"
     key, _value = self.first
     if key < start_date

--- a/lib/dashboard/version.rb
+++ b/lib/dashboard/version.rb
@@ -1,3 +1,3 @@
 module Dashboard
-  VERSION = "0.61.3"
+  VERSION = "0.61.4"
 end


### PR DESCRIPTION
Pass through mpan/mprn to OneDayAMRReading instead of active record id - use this in summarise data rather than the mpan_mprn method (which doesn't exist!)